### PR TITLE
prevent double sanitization of HTML entities

### DIFF
--- a/javascript/map.js
+++ b/javascript/map.js
@@ -20,7 +20,6 @@ var locationOptions = {
 };
 
 var entityMap = {
-    "&": "&amp;",
     "<": "&lt;",
     ">": "&gt;",
     '"': '&quot;',
@@ -107,7 +106,7 @@ function displayMessageOnMap(msg){
     // xss prevention hack
     msg.text = html_sanitize(msg.text);
 
-    msg.text = String(msg.text).replace(/[&<>"'\/卐卍]/g, function (s) {
+    msg.text = String(msg.text).replace(/[<>"'\/卐卍]/g, function (s) {
         return entityMap[s];
     });
 


### PR DESCRIPTION
By running the HTML through two sanitizers, HTML entities were showing up escaped. 
Removing the & from the manual, replace-based, sanitization should fix this. 

```
//example:
res = html_sanitize("h>").replace(/[&<>"'\/卐卍]/g, function (s) {
        return entityMap[s];
    });
res === "h&amp;gt;"
```
